### PR TITLE
Update to zotonic 0.10.0

### DIFF
--- a/controllers/controller_cron_admin.erl
+++ b/controllers/controller_cron_admin.erl
@@ -16,7 +16,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 
--module(resource_cron_admin).
+-module(controller_cron_admin).
 
 -export([
     %% wm resource:
@@ -28,7 +28,7 @@
     updates_listener_stream_loop/1
 ]).
 
--include_lib("resource_html.hrl").
+-include_lib("controller_html_helper.hrl").
 
 is_authorized(ReqData, Context) ->
     z_acl:wm_is_authorized(use, mod_cron, ReqData, Context).

--- a/dispatch/dispatch
+++ b/dispatch/dispatch
@@ -1,3 +1,3 @@
 [
-  {admin_mod_cron,  ["admin", "cron"],  resource_cron_admin,   [{template, "admin_mod_cron.tpl"}, {selected, "admin_mod_cron"}] }
+  {admin_mod_cron,  ["admin", "cron"],  controller_cron_admin,   [{template, "admin_mod_cron.tpl"}, {selected, "admin_mod_cron"}] }
 ].

--- a/mod_cron.erl
+++ b/mod_cron.erl
@@ -25,6 +25,9 @@
 -behaviour(gen_server).
 -mod_schema(1).
 
+%% admin menu
+-export([observe_admin_menu/3]).
+
 %% z_notifier pins
 -export([
 	observe_cron_job_insert/2,
@@ -49,10 +52,20 @@
 
 -include("include/cron.hrl").
 -include("include/zotonic.hrl").
+-include_lib("modules/mod_admin/include/admin_menu.hrl").
 
 %% Server will subscribe on this events on init() and unsubscribe on terminate().
 -define(MOD_SRV_SUBSCRIBE, [cron_job_start, cron_job_stop]).
 
+%% Add cron admin page to the admin menu tree
+observe_admin_menu(admin_menu, Acc, Context) ->
+    [
+     #menu_item{id=admin_mod_cron,
+                parent=admin_modules,
+                label=?__("Cron Tasks", Context),
+                url={admin_mod_cron},
+                visiblecheck={acl, use, ?MODULE}}
+     |Acc].
 
 %% @doc External management: add job to db and start.
 observe_cron_job_insert({cron_job_insert, JobId, Task}, Context) ->


### PR DESCRIPTION
This updates mod_cron to the latest Zotonic stable release - 0.10.0p1.
It basically involves renaming resources to controllers and including the right header files.

I have also added the mod_cron admin to the site's admin menu tree. 
